### PR TITLE
docs: update Ambassador Pages URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ It produces specification-compliant JSON manifests through a guided interface.
 
 Generator:
 
-https://hernancapucci.github.io/agent-manifest-ambassador/
+https://agent-manifest.github.io/agent-manifest-ambassador/
 
 ---
 


### PR DESCRIPTION
Update the Ambassador GitHub Pages URL in README.md following org migration.

Changed: `hernancapucci.github.io/agent-manifest-ambassador` → `agent-manifest.github.io/agent-manifest-ambassador`

The old URL returns HTTP 404. No other content changed.