### PR TITLE
docs: update repository URLs to organization

### DIFF
--- a/.well-known/agent-manifest-registry.json
+++ b/.well-known/agent-manifest-registry.json
@@ -3,13 +3,13 @@
   "registry_version": "1.0",
   "registry_name": "Agent Manifest Public Registry",
 
-  "registry_endpoint": "https://raw.githubusercontent.com/hernancapucci/agent-manifest-dataset/main/registry.json",
+  "registry_endpoint": "https://raw.githubusercontent.com/agent-manifest/agent-manifest-dataset/main/registry.json",
 
-  "dataset_repository": "https://github.com/hernancapucci/agent-manifest-dataset",
+  "dataset_repository": "https://github.com/agent-manifest/agent-manifest-dataset",
 
-  "specification_repository": "https://github.com/hernancapucci/agent-manifest",
+  "specification_repository": "https://github.com/agent-manifest/agent-manifest",
 
-  "registry_repository": "https://github.com/hernancapucci/agent-manifest-registry",
+  "registry_repository": "https://github.com/agent-manifest/agent-manifest-registry",
 
   "description": "Discovery endpoint for the Agent Manifest Public Registry."
 }

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository provides the official discovery endpoint for the public Agent Ma
 
 Discovery endpoint:
 
-https://raw.githubusercontent.com/hernancapucci/agent-manifest-registry/main/.well-known/agent-manifest-registry.json
+https://raw.githubusercontent.com/agent-manifest/agent-manifest-registry/main/.well-known/agent-manifest-registry.json
 
 ---
 
@@ -22,7 +22,7 @@ Defines the structure and fields of an Agent Manifest declaration.
 
 Specification repository:
 
-https://github.com/hernancapucci/agent-manifest
+https://github.com/agent-manifest/agent-manifest
 
 ---
 
@@ -52,7 +52,7 @@ All declared manifests are recorded in the public dataset repository.
 
 Dataset repository:
 
-https://github.com/hernancapucci/agent-manifest-dataset
+https://github.com/agent-manifest/agent-manifest-dataset
 
 Dataset structure:
 

--- a/REGISTRY_RULES.md
+++ b/REGISTRY_RULES.md
@@ -45,7 +45,7 @@ Registered manifests are stored in the public dataset repository.
 
 Repository:
 
-https://github.com/hernancapucci/agent-manifest-dataset
+https://github.com/agent-manifest/agent-manifest-dataset
 
 Structure:
 


### PR DESCRIPTION
Update stale GitHub repository URLs from `hernancapucci/*` to `agent-manifest/*` following org migration.

**Files changed (3):**
- `README.md` — 3 replacements (raw registry URL, specification repo, dataset repo)
- `REGISTRY_RULES.md` — 1 replacement (dataset repo)
- `.well-known/agent-manifest-registry.json` — 4 replacements (all 4 URL fields)

No prose or structure changed. Only URL strings replaced.