### PR TITLE
chore: ignore macOS metadata files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store


### PR DESCRIPTION
Adds a minimal `.gitignore` covering `.DS_Store` so macOS metadata never lands in the repository. No tracked files change. Ecosystem-wide hygiene; same one-line rule already present in agent-manifest-cli and agent-manifest-dataset.