### PR TITLE
docs: add agent_version to the required fields list

### DIFF
--- a/REGISTRY_RULES.md
+++ b/REGISTRY_RULES.md
@@ -23,6 +23,7 @@ A valid Agent Manifest must include the following fields:
 - `manifest_version`
 - `agent_id`
 - `agent_name`
+- `agent_version`
 - `owner`
 - `purpose`
 - `forbidden_actions`


### PR DESCRIPTION
The v1.0 schema's `required` array has 13 fields; `REGISTRY_RULES.md` §2 listed 12, omitting `agent_version`. The dataset's `SUBMIT.md` and its registration workflow already enforce it, so a submitter following the registry rules alone would produce a manifest the pipeline rejects. Doc-only, one line.