### PR TITLE
docs: describe the registry as structural mirror, not validator

### DIFF
--- a/DISCOVERY.md
+++ b/DISCOVERY.md
@@ -70,7 +70,7 @@ Before a manifest is added to the registry, the system should verify:
 - required Agent Manifest fields are present
 - the declaration is structurally valid
 
-Future validator layers may also perform semantic and trust checks.
+Semantic checks are a possible future research direction (non-normative).
 
 ---
 
@@ -141,14 +141,12 @@ The discovery architecture of Agent Manifest consists of:
 
 ## 10. Future Work
 
-Future discovery work may include:
+Future discovery work may include (possible future research, non-normative):
 
 - automatic domain scanning
 - repository discovery rules
 - signed manifest verification
-- trust metadata
 - multi-registry federation
-- compatibility with validator trust scores
 
 ---
 

--- a/DISCOVERY.md
+++ b/DISCOVERY.md
@@ -135,7 +135,7 @@ The discovery architecture of Agent Manifest consists of:
    the public archive of indexed declarations
 
 5. validator  
-   the system that checks compliance and trust properties
+   the system that checks structural conformance of declarations
 
 ---
 

--- a/FEDERATION.md
+++ b/FEDERATION.md
@@ -173,14 +173,12 @@ This approach makes Agent Manifest suitable for open ecosystems of AI agents.
 
 ## 11. Future Work
 
-Future federation work may include:
+Future federation work may include (possible future research, non-normative):
 
 - canonical rules for manifest discovery
-- domain-based trust models
 - signed manifests
-- validator trust scores
 - registry federation between multiple hubs
-- compatibility with boundary handshake protocols
+- compatibility with the Boundary Handshake conceptual framework
 
 ---
 

--- a/FEDERATION.md
+++ b/FEDERATION.md
@@ -153,7 +153,7 @@ The federated Agent Manifest model is composed of five layers:
    indexes and exposes discoverable manifests
 
 5. Validator  
-   verifies trust, structure, and compliance
+   verifies declarative structure and internal coherence
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Discovery and registry governance layer for Agent Manifest declarations.
 
-The Agent Manifest Registry defines the governance model and discovery layer for the Agent Manifest ecosystem. It specifies how AI agents declare themselves, how manifests are validated, and how declarations are recorded in the public registry.
+The Agent Manifest Registry defines the governance model and discovery layer for the Agent Manifest ecosystem. It documents how AI agents declare themselves, how manifests are validated by the registration pipeline (the Diplomat API and the dataset workflow), and how declarations are recorded in the public registry.
 
 This repository documents registry behavior and governance. The canonical runtime discovery endpoint is:
 
@@ -48,9 +48,9 @@ https://agent-manifest.github.io/agent-manifest-ambassador/
 
 ## 3. Registry (Diplomat)
 
-The Registry is responsible for validating and recording agent declarations.
+Validation is performed by the Diplomat, which checks each declaration against the canonical v1.0 JSON Schema before it is recorded. The registry index mirrors what has been recorded.
 
-It defines the rules and governance model that ensure manifests follow the specification and are stored transparently.
+This repository defines the rules and governance model under which that process stays public, reproducible, and auditable.
 
 ---
 

--- a/REGISTRY_RULES.md
+++ b/REGISTRY_RULES.md
@@ -2,7 +2,7 @@
 
 This document defines the rules governing the registration of Agent Manifests within the Agent Manifest ecosystem.
 
-The registry process ensures transparency, reproducibility, and a consistent declaration format for AI agents.
+The registry process is public, reproducible, and auditable, and uses a consistent declaration format for AI agents.
 
 ---
 


### PR DESCRIPTION
- README.md: validation is performed by the Diplomat against the canonical v1.0 JSON Schema; the registry index mirrors what has been recorded; governance described by its observable properties (public, reproducible, auditable).
- REGISTRY_RULES.md: same precision.
- DISCOVERY.md / FEDERATION.md: validator described as structural verification; trust-scoring items removed from future work (remaining items marked as possible future research, non-normative).